### PR TITLE
fix: set explicit acl_status to prevent drift

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -169,7 +169,7 @@ resource "alicloud_slb_listener" "http" {
   cookie_timeout      = 86400
   health_check        = "off"
   bandwidth           = 10
-  acl_status          = "on"
+  acl_status          = "off"
 }
 resource "alicloud_slb_attachment" "internet" {
   load_balancer_id = alicloud_slb_load_balancer.internet.id

--- a/main.tf
+++ b/main.tf
@@ -169,6 +169,7 @@ resource "alicloud_slb_listener" "http" {
   cookie_timeout      = 86400
   health_check        = "off"
   bandwidth           = 10
+  acl_status          = "on"
 }
 resource "alicloud_slb_attachment" "internet" {
   load_balancer_id = alicloud_slb_load_balancer.internet.id


### PR DESCRIPTION
The `alicloud_slb_listener.http` did not explicitly set `acl_status`, causing drift between apply state (`on`) and plan (`off`).