### PR TITLE
fix(classic-load-balance): set listener acl status

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_acl_status"></a> [acl\_status](#input_acl_status) | The ACL status of the HTTP listener. | `string` | `"on"` | no |
 | <a name="input_app_host_name"></a> [app\_host\_name](#input\_app\_host\_name) | The instance host name used to configure app instances. | `string` | `"tf-app-tier"` | no |
 | <a name="input_app_instance_cpu"></a> [app\_instance\_cpu](#input\_app\_instance\_cpu) | CPU core count is used to fetch instance types for launching app instances. | `number` | `2` | no |
 | <a name="input_app_instance_memory"></a> [app\_instance\_memory](#input\_app\_instance\_memory) | Memory size used to fetch instance types for launching app instances. | `number` | `4` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -35,6 +35,7 @@ module "classic-load-balance" {
   system_size       = "100"
 
   slb_max_bandwidth = "50"
+  acl_status        = "off"
 
   engine              = "MySQL"
   engine_version      = "5.6"

--- a/main.tf
+++ b/main.tf
@@ -169,6 +169,7 @@ resource "alicloud_slb_listener" "http" {
   cookie_timeout      = 86400
   health_check        = "off"
   bandwidth           = 10
+  acl_status          = "off"
 }
 resource "alicloud_slb_attachment" "internet" {
   load_balancer_id = alicloud_slb_load_balancer.internet.id
@@ -219,4 +220,3 @@ resource "alicloud_oss_bucket_acl" "default" {
   bucket = alicloud_oss_bucket.default.bucket
   acl    = var.bucket_acl
 }
-

--- a/main.tf
+++ b/main.tf
@@ -169,7 +169,7 @@ resource "alicloud_slb_listener" "http" {
   cookie_timeout      = 86400
   health_check        = "off"
   bandwidth           = 10
-  acl_status          = "off"
+  acl_status          = var.acl_status
 }
 resource "alicloud_slb_attachment" "internet" {
   load_balancer_id = alicloud_slb_load_balancer.internet.id

--- a/variables.tf
+++ b/variables.tf
@@ -262,6 +262,12 @@ variable "rds_database_name_prefix" {
 }
 
 # SLB variables
+variable "acl_status" {
+  description = "The ACL status of the HTTP listener."
+  default     = "on"
+  type        = string
+}
+
 variable "slb_intranet_name" {
   description = "The SLB intranet instance name used to create a new Intraner SLB instance. Default to `this_module_name`"
   default     = ""
@@ -302,4 +308,3 @@ variable "bucket_acl" {
   default     = "private"
   type        = string
 }
-


### PR DESCRIPTION
## Summary
- explicitly set the HTTP listener ACL status to `off`
- align configuration with the value returned after apply to prevent diff drift

## Validation
- terraform fmt -check -recursive: passed
- git diff --check: passed
- terraform init/validate: blocked by unavailable mirrors.aliyun.com
- plan/apply/destroy: not run locally